### PR TITLE
Fix an issue where cv includes itself

### DIFF
--- a/include/svr/cv.h
+++ b/include/svr/cv.h
@@ -2,6 +2,6 @@
 #ifndef __SVR_CV_H
 #define __SVR_CV_H
 
-#include <cv.h>
+#include <opencv/cv.h>
 
 #endif // #ifndef __SVR_CV_H


### PR DESCRIPTION
This should fix an issue where cv includes itself so programs using the svr library can be built outside of svr. Please test this if you can, but it works on my machine